### PR TITLE
Prevent the Package.el adding "(package-initialize)"

### DIFF
--- a/init.el
+++ b/init.el
@@ -1,3 +1,5 @@
+(setq package--init-file-ensured t)
+
 (add-to-list 'load-path (expand-file-name "lisp" user-emacs-directory))
 
 (defconst *spell-check-support-enabled* nil) ;; Enable with t if you prefer


### PR DESCRIPTION
Without the line "(setq package--init-file-ensured t)” at the beginning of init.el, Package.el will add "(package-initialize)" to init.el every time you run Emacs.  With few times running Emacs, a bunch of "(package-initialize)" will pollute the init.el like this:

> ;; Added by Package.el.  This must come before configurations of
;; installed packages.  Don't delete this line.  If you don't want it,
;; just comment it out by adding a semicolon to the start of the line.
;; You may delete these explanatory comments.
>
>;; Added by Package.el.  This must come before configurations of
;; installed packages.  Don't delete this line.  If you don't want it,
;; just comment it out by adding a semicolon to the start of the line.
;; You may delete these explanatory comments.
>(package-initialize)
>
>(package-initialize)
>...

And adding semicolon as the comments say has no use at all.
For the solution to this problem, go [here](https://www.reddit.com/r/emacs/comments/56fvgd/is_there_a_way_to_stop_emacs_from_adding_the/) for reference.
I don't know if this phenomenon appears only in my configuration with the OS win10 and GNU Emacs 25.1.1 (x86_64-w64-mingw32).